### PR TITLE
Changed linux path for saves

### DIFF
--- a/src/exe_path.cpp
+++ b/src/exe_path.cpp
@@ -50,7 +50,7 @@ static auto user_data_path_impl() -> std::filesystem::path
     const char* path = std::getenv("HOME");
     if (path == nullptr)
         return "";
-    return path;
+    return std::filesystem::path(path) / ".local/share";
 }
 
 #endif


### PR DESCRIPTION
On linux, app data directory should be saved either in .local/share , or have a . at the beginning (to be marked as hidden).

Users might not want a folder created in their home directory.